### PR TITLE
proxyRemover: visiting a proxy function should use the function scope

### DIFF
--- a/src/modifications/proxies/proxyRemover.ts
+++ b/src/modifications/proxies/proxyRemover.ts
@@ -228,7 +228,7 @@ export default class ProxyRemover extends Modification {
                         if (proxyFunction && !self.cyclicProxyFunctionIds.has(proxyFunction.id)) {
                             const args = (node as any).arguments;
                             let replacement: Shift.Node = proxyFunction.getReplacement(args);
-                            replacement = self.replaceProxyFunctionUsages(replacement, scope);
+                            replacement = self.replaceProxyFunctionUsages(replacement, proxyFunction.scope);
 
                             if (parent) {
                                 TraversalHelper.replaceNode(parent, node, replacement);


### PR DESCRIPTION
This avoid infinite loop when a symbol is redefined in the function's scope.

For example, the following should not result in infinite loop:
```
function f1(a,b) {
  return function (c,d) {
    function redefined(e,f){return e+f;}
    function f3(g, h){return redefined(g,h);}
    return function(i,j) {
      function redefined(k, l) {
        return f3(k, l);
      }
      return redefined(i,j)
    }(c,d);
  }(a,b);
};
console.log(f1(1,2));
```