### PR TITLE
Ability to parse ES Modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "js-deobfuscator",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "js-deobfuscator",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "license": "ISC",
             "dependencies": {
                 "commander": "^9.4.0",
@@ -2240,8 +2240,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
             "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@webpack-cli/info": {
             "version": "1.5.0",
@@ -2256,8 +2255,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
             "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -2322,8 +2320,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "ansi-styles": {
             "version": "4.3.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,8 @@ import { program } from 'commander';
 program
   .description('Deobfuscate a javascript file')
   .option('-i, --input [input_file]', 'The input file to deobfuscate', 'input/source.js')
-  .option('-o, --output [output_file]', 'The deobfuscated output file', 'output/output.js');
+  .option('-o, --output [output_file]', 'The deobfuscated output file', 'output/output.js')
+  .option('-m, --module', 'Parse ESModule');
 
 program.parse(process.argv);
 const options = program.opts();
@@ -18,7 +19,7 @@ if (!fs.existsSync(options.input)) {
 }
 
 const source = fs.readFileSync(options.input).toString();
-const output = deobfuscate(source);
+const output = deobfuscate(source, { isModule: options.module });
 
 fs.writeFileSync(options.output, output);
 console.info(`The output file ${options.output} has been created`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 export default interface Config {
     verbose: boolean;
+    isModule: boolean;
     arrays: ArraysConfig;
     proxyFunctions: ProxyFunctionsConfig;
     expressions: ExpressionsConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { parseScript } from 'shift-parser';
+import { parseModule, parseScript } from 'shift-parser';
 import * as Shift from 'shift-ast';
 import { codeGen, FormattedCodeGen } from 'shift-codegen';
 import Modification from './modification';
@@ -14,6 +14,7 @@ import StringDecoder from './modifications/expressions/stringDecoder';
 
 const defaultConfig: Config = {
     verbose: false,
+    isModule: false,
     arrays: {
         unpackArrays: true,
         removeArrays: true
@@ -40,8 +41,17 @@ const defaultConfig: Config = {
  * @param config The deobfuscation configuration (optional).
  * @returns The deobfuscated script.
  */
-export function deobfuscate(source: string, config: Config = defaultConfig): string {
-    const ast = parseScript(source) as Shift.Script;
+export function deobfuscate(source: string, parsedConfig?: Partial<Config>): string {
+    const config = Object.assign(defaultConfig, parsedConfig);
+
+    const ast = (() => {
+        if (config.isModule) {
+            return parseModule(source);
+        } else {
+            return parseScript(source);
+        }
+    })() as Shift.Script;
+
     const modifications: Modification[] = [];
 
     if (config.proxyFunctions.replaceProxyFunctions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const defaultConfig: Config = {
  * @returns The deobfuscated script.
  */
 export function deobfuscate(source: string, parsedConfig?: Partial<Config>): string {
-    const config = Object.assign(defaultConfig, parsedConfig);
+    const config = Object.assign({}, defaultConfig, parsedConfig);
 
     const ast = (() => {
         if (config.isModule) {


### PR DESCRIPTION
according to https://github.com/shapesecurity/shift-parser-js/issues/258 we should use `parseModule` function in order to parse `import` and `export` statements

added option `-m` or `--module` to do so